### PR TITLE
Fixed build: switched to the correct variant of the sprintf function

### DIFF
--- a/src/dwst-exception-dialog.c
+++ b/src/dwst-exception-dialog.c
@@ -87,19 +87,19 @@ static void printAddr( HWND hwnd,const TCHAR *beg,int num,
 
     if( num>=0 )
     {
-      _stprintf( hexNum,20,TEXT("%02d"),num );
+      _sntprintf( hexNum,20,TEXT("%02d"),num );
       Edit_ReplaceSel( hwnd,hexNum );
     }
 
     Edit_ReplaceSel( hwnd,TEXT(": 0x") );
-    _stprintf( hexNum,20,TEXT("%p"),ptr );
+    _sntprintf( hexNum,20,TEXT("%p"),ptr );
     Edit_ReplaceSel( hwnd,hexNum );
   }
   else
   {
-    _stprintf( hexNum,20,TEXT("%*s"),14,TEXT("") );
+    _sntprintf( hexNum,20,TEXT("%*s"),14,TEXT("") );
     Edit_ReplaceSel( hwnd,hexNum );
-    _stprintf( hexNum,20,TEXT("%*s"),2+(int)sizeof(void*)*2,TEXT("") );
+    _sntprintf( hexNum,20,TEXT("%*s"),2+(int)sizeof(void*)*2,TEXT("") );
     Edit_ReplaceSel( hwnd,hexNum );
   }
 
@@ -111,13 +111,13 @@ static void printAddr( HWND hwnd,const TCHAR *beg,int num,
     if( posLine>0 )
     {
       Edit_ReplaceSel( hwnd,TEXT(":") );
-      _stprintf( hexNum,20,TEXT("%d"),posLine );
+      _sntprintf( hexNum,20,TEXT("%d"),posLine );
       Edit_ReplaceSel( hwnd,hexNum );
 
       if( posColumn>0 )
       {
         Edit_ReplaceSel( hwnd,TEXT(":") );
-        _stprintf( hexNum,20,TEXT("%d"),posColumn );
+        _sntprintf( hexNum,20,TEXT("%d"),posColumn );
         Edit_ReplaceSel( hwnd,hexNum );
       }
     }
@@ -308,7 +308,7 @@ static LONG WINAPI exceptionPrinter( LPEXCEPTION_POINTERS ep )
   TCHAR hexNum[20];
 
   Edit_ReplaceSel( textHwnd,TEXT("code: 0x") );
-  _stprintf( hexNum,20,TEXT("%08lX"),code );
+  _sntprintf( hexNum,20,TEXT("%08lX"),code );
   Edit_ReplaceSel( textHwnd,hexNum );
   if( desc )
     Edit_ReplaceSel( textHwnd,desc );
@@ -323,7 +323,7 @@ static LONG WINAPI exceptionPrinter( LPEXCEPTION_POINTERS ep )
         flag==8?TEXT("data execution prevention"):
         (flag?TEXT("write access"):TEXT("read access")) );
     Edit_ReplaceSel( textHwnd,TEXT(" violation at 0x") );
-    _stprintf( hexNum,20,TEXT("%p"),(void*)addr );
+    _sntprintf( hexNum,20,TEXT("%p"),(void*)addr );
     Edit_ReplaceSel( textHwnd,hexNum );
     Edit_ReplaceSel( textHwnd,TEXT("\r\n") );
   }


### PR DESCRIPTION
The current state of the repository doesn't build with the recent MinGW/Msys2 compiler.
The reason is that the `_stprintf` which translates to `_swprintf` by default is declared as
`int __cdecl _swprintf(wchar_t * __restrict__ _Dest,const wchar_t * __restrict__ _Format,...)` (missing count parameter).
The correct variant of the function from the sprintf family is the
`int __cdecl _snwprintf(wchar_t * __restrict__ _Dest,size_t _Count,const wchar_t * __restrict__ _Format,...)`.