### PR TITLE
Add support for ARM64

### DIFF
--- a/src/dwst-exception.c
+++ b/src/dwst-exception.c
@@ -55,11 +55,21 @@ int captureStackTrace( ULONG_PTR *frameAddr,uintptr_t *frames,int size )
 // cip ... current instruction pointer
 // cfp ... current frame pointer
 #ifdef _WIN64
+#if defined(__aarch64__) || defined(_M_ARM64)
+// Defaults to ARM64
+#define csp Sp
+#define cip Pc
+#define cfp Fp
+#define MACH_TYPE IMAGE_FILE_MACHINE_ARM64
+#else
+// Defaults to AMD64
 #define csp Rsp
 #define cip Rip
 #define cfp Rbp
 #define MACH_TYPE IMAGE_FILE_MACHINE_AMD64
+#endif
 #else
+// Defaults to i386
 #define csp Esp
 #define cip Eip
 #define cfp Ebp


### PR DESCRIPTION
I tried to compile dwarfstack for running on Windows on ARM, but I discovered that it was not supported.
Hopefully, it was easy to add it.

The patch just tests `__aarch64__` (for GNU GCC) and `_M_ARM64` (for MSVC) when `_WIN64` is detected and it applies the changes for addressing the program counter, the stack pointer and the frame pointer for ARM64.

The patch has been tested with TRX, an open source re-implementation of Tomb Raider I and Tomb Raider II game engines, and it worked fine.
